### PR TITLE
changelog: shrink the Tags column and ellipsize overflow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,11 @@ UNRELEASED
       middleware no longer overwrites a header already set by the
       handler. (Jelmer Vernooĳ, #503144)
 
+    - Shrink the changelog "Tags" column from 240px to 120px and ellipsize
+      overflowing tag lists, freeing horizontal space for the summary
+      column. The full tag text is still available as a cell tooltip.
+      (Jelmer Vernooĳ, #708900)
+
 3.0.0 [22Apr2026]
 -----------------
 

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -223,10 +223,19 @@ td.icocell {
     width: 18px;
     }
 th.authorcell,
-td.autcell,
+td.autcell {
+    width: 240px;
+    }
+/* Tags are usually absent or short; don't steal space from the
+   summary column. Long tag lists are truncated with an ellipsis
+   and shown in full via the cell's `title` tooltip (bug #708900). */
 th.tagscell,
 td.tagcell {
-    width: 240px;
+    width: 120px;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     }
 th.datecell,
 td.date {

--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -61,7 +61,7 @@ To get this branch, use: <br/>
   </div>
 </td>
 <td class="autcell">{{ c.author }}</td>
-{% if show_tag_col %}<td class="tagcell">{{ c.tags }}</td>{% endif %}
+{% if show_tag_col %}<td class="tagcell" title="{{ c.tags }}">{{ c.tags }}</td>{% endif %}
 <td class="date"><span title="{{ c.utc_iso }}">{{ c.relative_date }}</span></td>
 <td class="diffr"><a title="Show diff at revision {{ c.revno }}" href="{{ url_prefix }}/revision/{{ c.revno }}"><img alt="Diff" src="/static/images/ico_diff.gif" /></a></td>
 <td class="downr"><a href="{{ url_prefix }}/files/{{ c.revno }}" title="Files at revision {{ c.revno }}"><img alt="Files" src="/static/images/ico_file.gif" /></a></td>


### PR DESCRIPTION
The Tags cell shared a 240px width with the Authors cell, eating roughly 480px before the Summary column could render. Most branches have at most one short tag per revision, so give Tags its own 120px width with an `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` stack, and carry the full tag list through as a `title` tooltip so nothing is lost on hover.

Fixes: https://bugs.launchpad.net/loggerhead/+bug/708900