### PR TITLE
revision: wrap long commit-message strings so they don't overflow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,12 @@ UNRELEASED
       column. The full tag text is still available as a cell tooltip.
       (Jelmer Vernooĳ, #708900)
 
+    - Break unbreakable strings (such as long URLs) in the revision
+      detail's commit-message block so they no longer overflow and
+      cover up the files-changed list next to it. Move the
+      ``.information`` styling out of an inline ``style=`` attribute
+      into ``diff.css``. (Jelmer Vernooĳ, #449980)
+
 3.0.0 [22Apr2026]
 -----------------
 

--- a/static/css/diff.css
+++ b/static/css/diff.css
@@ -32,6 +32,16 @@ ul#list-files li.desc {
     font-size:  77%;
     color: #666;
     }
+/* Commit message body inside the infobox. Preserve the author's
+   linebreaks and indentation (pre-wrap), but break unbreakable strings
+   such as long URLs so they don't overflow into the files list on the
+   right (bug #449980). */
+.information {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    font-family: ui-monospace, monospace;
+    }
 /*Diff Boxes*/
 .diffBox {
     width: 100%;

--- a/templates/revision.html
+++ b/templates/revision.html
@@ -79,7 +79,7 @@ var path_to_id = {{ path_to_id|safe }};
 {% endfor %}
 {% endif %}
 
-<div class="information" style="white-space: pre-wrap; font-family: ui-monospace, monospace;">{{ message }}</div>
+<div class="information">{{ message }}</div>
 </div>
 
 <ul id="list-files">


### PR DESCRIPTION
The commit-message block sits inside a 493px floated column, with the files-changed list floated next to it. `white-space: pre-wrap` alone only wraps on whitespace, so a long URL or other unbreakable string in the message spilled over and obscured the adjacent files list. Add `overflow-wrap: anywhere` + `word-break: break-word` on `.information` so the message stays inside its column.

Also lift the `.information` styling out of the inline `style=` attribute in revision.html into diff.css.

Fixes: https://bugs.launchpad.net/loggerhead/+bug/449980