### PR TITLE
changelog: also render pagination above the table

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,11 @@ UNRELEASED
       ``.information`` styling out of an inline ``style=`` attribute
       into ``diff.css``. (Jelmer Vernooĳ, #449980)
 
+    - Also render the Newer/Older pagination controls above the
+      changelog table, not only below it, so users don't have to
+      scroll past the full page to navigate. (Jelmer Vernooĳ,
+      #522118)
+
 3.0.0 [22Apr2026]
 -----------------
 

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -297,10 +297,21 @@ li.files#directory {
 /* =========================
    Pagination
 */
-ul#pages {
+ul#pages,
+ul.pages {
     float: right;
+    list-style: none;
+    padding: 0;
     }
-#pages li {
+/* The top copy sits on its own line above the table so the
+   controls don't collide with the expand/collapse row
+   (bug #522118). */
+ul.pages-top {
+    clear: both;
+    margin-bottom: 4px;
+    }
+#pages li,
+.pages li {
     font-size: 77%;
     font-weight: bold;
     float: left;

--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -32,6 +32,19 @@ To get this branch, use: <br/>
 <p class="expand show_if_js" id="expand_all"><a href="#"><img alt="expand all" src="/static/images/treeCollapsed.png" /> expand all</a></p>
 <p class="expand" id="collapse_all" style="display:none;"><a href="#"><img alt="collapse all" src="/static/images/treeExpanded.png" /> collapse all</a></p>
 
+{% if prev_page_url.is_some() || next_page_url.is_some() %}
+<ul class="pages pages-top">
+{% match prev_page_url %}
+  {% when Some with (u) %}<li class="previous"><a href="{{ u }}">&laquo; Newer</a></li>
+  {% when None %}
+{% endmatch %}
+{% match next_page_url %}
+  {% when Some with (u) %}<li class="next"><a href="{{ u }}">Older &raquo;</a></li>
+  {% when None %}
+{% endmatch %}
+</ul>
+{% endif %}
+
 <table id="logentries">
 <tr class="logheader">
 <th class="revisionnumber">Rev</th>


### PR DESCRIPTION
Previously, "Newer"/"Older" only appeared below the log table, so users on long pages had to scroll all the way down before they could move between pages. Render the same controls above the table too.

HTML doesn't allow two elements with the same id, so the bottom copy keeps `id="pages"` and the top copy uses only classes; the shared pagination styling is also accessible via the new `.pages` selector.

Fixes: https://bugs.launchpad.net/loggerhead/+bug/522118