### PR TITLE
Convert README.rst to README.md and fix Cargo.toml metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ rust-version = "1.83"
 license = "GPL-2.0-or-later"
 description = "Web viewer for Bazaar/Breezy branches"
 homepage = "https://www.breezy-vcs.org/"
-repository = "https://code.launchpad.net/loggerhead"
+repository = "https://github.com/breezy-team/loggerhead"
 authors = ["Jelmer Vernooij <jelmer@jelmer.uk>"]
+readme = "README.md"
 
 [[bin]]
 name = "loggerhead-serve"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Loggerhead
-==========
+# Loggerhead
 
-Overview
---------
+## Overview
 
 Loggerhead is a web viewer for Breezy. Its lets users do stuff like:
 
@@ -12,15 +10,13 @@ Loggerhead is a web viewer for Breezy. Its lets users do stuff like:
 * perform searches.
 
 
-Documentation
--------------
+## Documentation
 
 See docs/index.rst for installation instructions and basic
 documentation.
 
 
-Licensing
----------
+## Licensing
 
 This software is licensed under the GPL Version 2 or later.
 Please see the file COPYING.txt for the licence details.


### PR DESCRIPTION
Point repository URL at the GitHub mirror and reference the new README.